### PR TITLE
Add placeholder Data/AI toolkit features

### DIFF
--- a/frontend/src/app/data/application-map/page.tsx
+++ b/frontend/src/app/data/application-map/page.tsx
@@ -1,32 +1,60 @@
 "use client";
 import { useState } from "react";
+import * as XLSX from "xlsx";
 
-type Out = { mappings: Record<string,string> };
+interface Mapping {
+  data_entity: string;
+  application: string;
+  relationship: string;
+  rationale: string;
+}
+
+interface MapOut { mappings: Mapping[] }
 
 export default function DataApplicationMap() {
-  const [datasets, setDatasets] = useState<string[]>(["Customer Data", "Order Data"]);
-  const [apps, setApps] = useState<string[]>(["CRM", "ERP"]);
-  const [out, setOut] = useState<Out | null>(null);
+  const [dataEntities, setDataEntities] = useState<string[]>(["Customer", "Order"]);
+  const [applications, setApplications] = useState<string[]>(["CRM", "ERP"]);
+  const [out, setOut] = useState<MapOut | null>(null);
   const [err, setErr] = useState("");
   const [loading, setLoading] = useState(false);
 
-  function updateList(list:string[], setter:(v:string[])=>void, i:number, val:string){ setter(list.map((v,idx)=>idx===i?val:v)); }
-  function addDataset(){ setDatasets(prev=>[...prev,""]); }
-  function removeDataset(i:number){ setDatasets(prev=>prev.filter((_,idx)=>idx!==i)); }
-  function addApp(){ setApps(prev=>[...prev,""]); }
-  function removeApp(i:number){ setApps(prev=>prev.filter((_,idx)=>idx!==i)); }
+  function update(list: string[], setter: (v: string[]) => void, i: number, val: string) {
+    setter(list.map((v, idx) => idx === i ? val : v));
+  }
+  function add(setter: (v: string[]) => void) { setter(prev => [...prev, ""]); }
+  function remove(list: string[], setter: (v: string[]) => void, i: number) { setter(list.filter((_, idx) => idx !== i)); }
 
-  async function onSubmit(e:React.FormEvent){
+  async function onSubmit(e: React.FormEvent) {
     e.preventDefault(); setErr(""); setOut(null); setLoading(true);
     try {
       const r = await fetch("/api/ai/data/application/map", {
-        method:"POST", headers:{"content-type":"application/json"},
-        body: JSON.stringify({ datasets, applications: apps })
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ data_entities: dataEntities, applications })
       });
       const j = await r.json();
-      if(!r.ok) throw new Error(j?.detail || "Request failed");
-      setOut(j as Out);
-    } catch(e){ setErr(e instanceof Error?e.message:"Request failed"); } finally { setLoading(false); }
+      if (!r.ok) throw new Error(j?.detail || "Request failed");
+      setOut(j as MapOut);
+    } catch (e) { setErr(e instanceof Error ? e.message : "Request failed"); }
+    finally { setLoading(false); }
+  }
+
+  function download() {
+    if (!out) return;
+    const wb = XLSX.utils.book_new();
+    const sheet = XLSX.utils.json_to_sheet(out.mappings.map(m => ({
+      Data_Entity: m.data_entity,
+      Application: m.application,
+      Relationship: m.relationship,
+      Rationale: m.rationale
+    })));
+    XLSX.utils.book_append_sheet(wb, sheet, "Mappings");
+    const wbout = XLSX.write(wb, { bookType: "xlsx", type: "array" });
+    const blob = new Blob([wbout], { type: "application/octet-stream" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url; a.download = "data_application_mapping.xlsx"; a.click();
+    URL.revokeObjectURL(url);
   }
 
   return (
@@ -35,38 +63,43 @@ export default function DataApplicationMap() {
         <h1 className="text-3xl font-bold">Data-Application Mapping</h1>
         <form onSubmit={onSubmit} className="space-y-4">
           <div className="space-y-2">
-            <div className="text-sm font-medium">Datasets</div>
-            {datasets.map((d,i)=>(
+            <div className="text-sm font-medium">Data Entities</div>
+            {dataEntities.map((d, i) => (
               <div key={i} className="flex gap-2">
-                <input value={d} onChange={e=>updateList(datasets,setDatasets,i,e.target.value)} className="flex-1 p-2 rounded-md border border-black/10" />
-                <button type="button" onClick={()=>removeDataset(i)} className="px-3 py-2 rounded-md border border-black/10 hover:bg-black/5">Remove</button>
+                <input value={d} onChange={e => update(dataEntities, setDataEntities, i, e.target.value)} className="flex-1 p-2 rounded-md border border-black/10" />
+                <button type="button" onClick={() => remove(dataEntities, setDataEntities, i)} className="px-3 py-2 rounded-md border border-black/10 hover:bg-black/5">Remove</button>
               </div>
             ))}
-            <button type="button" onClick={addDataset} className="px-3 py-2 rounded-md border border-black/10 hover:bg-black/5">Add dataset</button>
+            <button type="button" onClick={() => add(setDataEntities)} className="px-3 py-2 rounded-md border border-black/10 hover:bg-black/5">Add data entity</button>
           </div>
           <div className="space-y-2">
             <div className="text-sm font-medium">Applications</div>
-            {apps.map((a,i)=>(
+            {applications.map((a, i) => (
               <div key={i} className="flex gap-2">
-                <input value={a} onChange={e=>updateList(apps,setApps,i,e.target.value)} className="flex-1 p-2 rounded-md border border-black/10" />
-                <button type="button" onClick={()=>removeApp(i)} className="px-3 py-2 rounded-md border border-black/10 hover:bg-black/5">Remove</button>
+                <input value={a} onChange={e => update(applications, setApplications, i, e.target.value)} className="flex-1 p-2 rounded-md border border-black/10" />
+                <button type="button" onClick={() => remove(applications, setApplications, i)} className="px-3 py-2 rounded-md border border-black/10 hover:bg-black/5">Remove</button>
               </div>
             ))}
-            <button type="button" onClick={addApp} className="px-3 py-2 rounded-md border border-black/10 hover:bg-black/5">Add application</button>
+            <button type="button" onClick={() => add(setApplications)} className="px-3 py-2 rounded-md border border-black/10 hover:bg-black/5">Add application</button>
           </div>
-          <button disabled={loading||datasets.length===0||apps.length===0} className="px-4 py-2 rounded-md bg-indigo-600 text-white disabled:opacity-50">{loading?"Mapping...":"Map"}</button>
+          <button disabled={loading || dataEntities.length === 0 || applications.length === 0} className="px-4 py-2 rounded-md bg-indigo-600 text-white disabled:opacity-50">{loading?"Mapping...":"Map"}</button>
         </form>
         {err && <div className="p-3 border border-red-200 text-red-700 rounded">{err}</div>}
         {out && (
-          <div className="rounded-xl border border-black/10 overflow-hidden">
-            <table className="w-full">
-              <thead><tr className="bg-black/5"><th className="text-left p-2">Dataset</th><th className="text-left p-2">Application</th></tr></thead>
-              <tbody>
-                {Object.entries(out.mappings).map(([ds,app])=> (
-                  <tr key={ds} className="odd:bg-black/5"><td className="p-2 align-top">{ds}</td><td className="p-2">{app}</td></tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="space-y-3">
+            <div className="rounded-xl border border-black/10 overflow-hidden">
+              <table className="w-full">
+                <thead>
+                  <tr className="bg-black/5"><th className="text-left p-2">Data Entity</th><th className="text-left p-2">Application</th><th className="text-left p-2">Relationship</th><th className="text-left p-2">Rationale</th></tr>
+                </thead>
+                <tbody>
+                  {out.mappings.map((m,i) => (
+                    <tr key={i} className="odd:bg-black/5"><td className="p-2 align-top">{m.data_entity}</td><td className="p-2 align-top">{m.application}</td><td className="p-2 align-top">{m.relationship}</td><td className="p-2 text-sm">{m.rationale}</td></tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <button onClick={download} className="px-4 py-2 rounded-md border border-black/10 hover:bg-black/5">Download Excel</button>
           </div>
         )}
       </div>

--- a/frontend/src/app/data/conceptual-model/page.tsx
+++ b/frontend/src/app/data/conceptual-model/page.tsx
@@ -1,29 +1,56 @@
 "use client";
 import { useState } from "react";
+import * as XLSX from "xlsx";
 
-type Out = { model: string[] };
+interface Entity {
+  subject_area: string;
+  entity: string;
+  description: string;
+}
+
+interface ModelOut {
+  subject_areas: string[];
+  entities: Entity[];
+}
 
 export default function ConceptualDataModel() {
-  const [entities, setEntities] = useState<string[]>(["Customer", "Order", "Product"]);
-  const [out, setOut] = useState<Out | null>(null);
+  const [context, setContext] = useState("");
+  const [out, setOut] = useState<ModelOut | null>(null);
   const [err, setErr] = useState("");
   const [loading, setLoading] = useState(false);
 
-  function updateEntity(i:number,val:string){ setEntities(prev=>prev.map((e,idx)=>idx===i?val:e)); }
-  function addEntity(){ setEntities(prev=>[...prev, ""]); }
-  function removeEntity(i:number){ setEntities(prev=>prev.filter((_,idx)=>idx!==i)); }
-
-  async function onSubmit(e:React.FormEvent){
+  async function onSubmit(e: React.FormEvent) {
     e.preventDefault(); setErr(""); setOut(null); setLoading(true);
     try {
       const r = await fetch("/api/ai/data/conceptual-model", {
-        method:"POST", headers:{"content-type":"application/json"},
-        body: JSON.stringify({ entities })
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ context })
       });
       const j = await r.json();
-      if(!r.ok) throw new Error(j?.detail || "Request failed");
-      setOut(j as Out);
-    } catch(e){ setErr(e instanceof Error?e.message:"Request failed"); } finally { setLoading(false); }
+      if (!r.ok) throw new Error(j?.detail || "Request failed");
+      setOut(j as ModelOut);
+    } catch (e) { setErr(e instanceof Error ? e.message : "Request failed"); }
+    finally { setLoading(false); }
+  }
+
+  function download() {
+    if (!out) return;
+    const wb = XLSX.utils.book_new();
+    const saSheet = XLSX.utils.aoa_to_sheet([["Subject Area"], ...out.subject_areas.map(a => [a])]);
+    const entSheet = XLSX.utils.json_to_sheet(out.entities.map(e => ({
+      Subject_Area: e.subject_area,
+      Entity: e.entity,
+      Description: e.description
+    })));
+    XLSX.utils.book_append_sheet(wb, saSheet, "Subject Areas");
+    XLSX.utils.book_append_sheet(wb, entSheet, "Entities");
+    const wbout = XLSX.write(wb, { bookType: "xlsx", type: "array" });
+    const blob = new Blob([wbout], { type: "application/octet-stream" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url; a.download = "conceptual_data_model.xlsx"; a.click();
+    URL.revokeObjectURL(url);
   }
 
   return (
@@ -31,20 +58,29 @@ export default function ConceptualDataModel() {
       <div className="mx-auto max-w-4xl space-y-4">
         <h1 className="text-3xl font-bold">Conceptual Data Model Generator</h1>
         <form onSubmit={onSubmit} className="space-y-4">
-          {entities.map((e,i)=>(
-            <div key={i} className="flex gap-2">
-              <input value={e} onChange={ev=>updateEntity(i,ev.target.value)} className="flex-1 p-2 rounded-md border border-black/10" />
-              <button type="button" onClick={()=>removeEntity(i)} className="px-3 py-2 rounded-md border border-black/10 hover:bg-black/5">Remove</button>
-            </div>
-          ))}
-          <button type="button" onClick={addEntity} className="px-3 py-2 rounded-md border border-black/10 hover:bg-black/5">Add entity</button>
-          <button disabled={loading||entities.length===0} className="px-4 py-2 rounded-md bg-indigo-600 text-white disabled:opacity-50">{loading?"Generating...":"Generate model"}</button>
+          <div>
+            <label className="block text-sm font-medium">Company Context</label>
+            <textarea value={context} onChange={e=>setContext(e.target.value)} className="w-full h-40 p-3 rounded-md border border-black/10" />
+          </div>
+          <button disabled={loading || !context.trim()} className="px-4 py-2 rounded-md bg-indigo-600 text-white disabled:opacity-50">{loading?"Generating...":"Generate"}</button>
         </form>
         {err && <div className="p-3 border border-red-200 text-red-700 rounded">{err}</div>}
         {out && (
-          <ul className="list-disc pl-6 space-y-1">
-            {out.model.map((m,i)=>(<li key={i}>{m}</li>))}
-          </ul>
+          <div className="space-y-4">
+            <div>
+              <h2 className="text-xl font-semibold">Subject Areas</h2>
+              <ul className="list-disc pl-6">
+                {out.subject_areas.map((sa,i)=>(<li key={i}>{sa}</li>))}
+              </ul>
+            </div>
+            <div>
+              <h2 className="text-xl font-semibold">Data Entities</h2>
+              <ul className="list-disc pl-6 space-y-1">
+                {out.entities.map((e,i)=>(<li key={i}><span className="font-medium">{e.subject_area}:</span> {e.entity} – {e.description}</li>))}
+              </ul>
+            </div>
+            <button onClick={download} className="px-4 py-2 rounded-md border border-black/10 hover:bg-black/5">Download Excel</button>
+          </div>
         )}
       </div>
     </main>

--- a/frontend/src/app/use-cases/customise/page.tsx
+++ b/frontend/src/app/use-cases/customise/page.tsx
@@ -1,26 +1,55 @@
 "use client";
 import { useState } from "react";
+import * as XLSX from "xlsx";
 
-type Out = { custom_use_case: string };
+interface Result {
+  use_case: string;
+  customised: string;
+  score: number;
+  rationale: string;
+}
 
-export default function UseCaseCustomise() {
-  const [template, setTemplate] = useState("Automate {context} with AI");
-  const [context, setContext] = useState("invoice processing");
+interface Out { results: Result[] }
+
+export default function UseCaseCustomiser() {
+  const [context, setContext] = useState("");
+  const [useCases, setUseCases] = useState("Predict churn\nAutomate billing");
   const [out, setOut] = useState<Out | null>(null);
   const [err, setErr] = useState("");
   const [loading, setLoading] = useState(false);
 
-  async function onSubmit(e:React.FormEvent){
+  async function onSubmit(e: React.FormEvent) {
     e.preventDefault(); setErr(""); setOut(null); setLoading(true);
     try {
+      const list = useCases.split("\n").map(s => s.trim()).filter(Boolean);
       const r = await fetch("/api/ai/use-case/customise", {
-        method:"POST", headers:{"content-type":"application/json"},
-        body: JSON.stringify({ template, context })
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ use_cases: list, context })
       });
       const j = await r.json();
-      if(!r.ok) throw new Error(j?.detail || "Request failed");
+      if (!r.ok) throw new Error(j?.detail || "Request failed");
       setOut(j as Out);
-    } catch(e){ setErr(e instanceof Error?e.message:"Request failed"); } finally { setLoading(false); }
+    } catch (e) { setErr(e instanceof Error ? e.message : "Request failed"); }
+    finally { setLoading(false); }
+  }
+
+  function download() {
+    if (!out) return;
+    const wb = XLSX.utils.book_new();
+    const sheet = XLSX.utils.json_to_sheet(out.results.map(r => ({
+      Use_Case: r.use_case,
+      Customised: r.customised,
+      Score: r.score,
+      Rationale: r.rationale
+    })));
+    XLSX.utils.book_append_sheet(wb, sheet, "Customised Use Cases");
+    const wbout = XLSX.write(wb, { bookType: "xlsx", type: "array" });
+    const blob = new Blob([wbout], { type: "application/octet-stream" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url; a.download = "customised_use_cases.xlsx"; a.click();
+    URL.revokeObjectURL(url);
   }
 
   return (
@@ -29,18 +58,32 @@ export default function UseCaseCustomise() {
         <h1 className="text-3xl font-bold">AI Use Case Customiser</h1>
         <form onSubmit={onSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium">Template</label>
-            <input value={template} onChange={e=>setTemplate(e.target.value)} className="w-full p-2 rounded-md border border-black/10" />
+            <label className="block text-sm font-medium">Company Context</label>
+            <textarea value={context} onChange={e=>setContext(e.target.value)} className="w-full h-32 p-3 rounded-md border border-black/10" />
           </div>
           <div>
-            <label className="block text-sm font-medium">Context</label>
-            <input value={context} onChange={e=>setContext(e.target.value)} className="w-full p-2 rounded-md border border-black/10" />
+            <label className="block text-sm font-medium">Use Cases (one per line)</label>
+            <textarea value={useCases} onChange={e=>setUseCases(e.target.value)} className="w-full h-40 p-3 rounded-md border border-black/10" />
           </div>
-          <button disabled={loading||!template||!context} className="px-4 py-2 rounded-md bg-indigo-600 text-white disabled:opacity-50">{loading?"Customising...":"Customise"}</button>
+          <button disabled={loading || !useCases.trim()} className="px-4 py-2 rounded-md bg-indigo-600 text-white disabled:opacity-50">{loading?"Customising...":"Customise"}</button>
         </form>
         {err && <div className="p-3 border border-red-200 text-red-700 rounded">{err}</div>}
         {out && (
-          <div className="p-4 border border-black/10 rounded-md bg-black/5">{out.custom_use_case}</div>
+          <div className="space-y-3">
+            <div className="rounded-xl border border-black/10 overflow-hidden">
+              <table className="w-full">
+                <thead>
+                  <tr className="bg-black/5"><th className="text-left p-2">Use Case</th><th className="text-left p-2">Customised</th><th className="text-left p-2">Score</th><th className="text-left p-2">Rationale</th></tr>
+                </thead>
+                <tbody>
+                  {out.results.map((r,i)=> (
+                    <tr key={i} className="odd:bg-black/5"><td className="p-2 align-top">{r.use_case}</td><td className="p-2 align-top">{r.customised}</td><td className="p-2 align-top">{r.score}</td><td className="p-2 text-sm">{r.rationale}</td></tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <button onClick={download} className="px-4 py-2 rounded-md border border-black/10 hover:bg-black/5">Download Excel</button>
+          </div>
         )}
       </div>
     </main>


### PR DESCRIPTION
## Summary
- add placeholder conceptual data model generator that derives subject areas and entities from context
- produce mock data-application mapping with relationship and rationale
- rank and customise AI use cases based on provided context

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689675f00a68832a835dacc44fd4010d