### PR TITLE
fix: include effect dependencies

### DIFF
--- a/frontend/src/app/pain-points/themes/page.tsx
+++ b/frontend/src/app/pain-points/themes/page.tsx
@@ -62,13 +62,13 @@ export default function PainPointThemesPage() {
         if (obj.textCols) setTextCols(obj.textCols);
       } catch {}
     }
-  }, [excel.file?.name]);
+  }, [excel.file]);
 
   useEffect(() => {
     const key = excel.file ? `themes:${excel.file.name}` : null;
     if (!key) return;
     localStorage.setItem(key, JSON.stringify({ idCol, textCols }));
-  }, [excel.file?.name, idCol, textCols]);
+  }, [excel.file, idCol, textCols]);
 
   async function downloadXlsx() {
     try {

--- a/frontend/src/components/ExcelPicker.tsx
+++ b/frontend/src/components/ExcelPicker.tsx
@@ -92,7 +92,7 @@ export function ExcelPicker({ onChange, accept = ".csv,.xls,.xlsx,.xlsm", classN
     const hdr = (data[idx] || []).map((h) => String(h));
     setHeaders(hdr);
     setPreview(data.slice(idx, idx + 6));
-  }, [headerRowIndex]);
+  }, [headerRowIndex, data]);
 
   useEffect(() => {
     onChange({ file, sheet, headers, preview, headerRowIndex });


### PR DESCRIPTION
## Summary
- include excel file in theme persistence effects
- recompute header preview when file data changes

## Testing
- `./scripts/test-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896c4fec1d4832abd1c2b44f948f9c1