### PR TITLE
feat: add logged test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Logs
 logs
+test-results/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/architecture.md
+++ b/architecture.md
@@ -102,6 +102,12 @@ Edge API routes (proxy to FastAPI):
 - Backend: `OPENAI_API_KEY` (optional; if missing, endpoints use heuristics), `OPENAI_MODEL` (default gpt-4o-mini), `OPENAI_TEMPERATURE` (default 0.2). `.env` is auto-loaded.
 - Frontend: `NEXT_PUBLIC_API_BASE_URL` (defaults to http://127.0.0.1:8000 for local dev; in Docker, set to http://api:8000).
 
+## Testing
+
+- Run `./scripts/test-all.sh` to execute backend Pytest suites and frontend ESLint checks.
+- Output from each stage is written to `test-results/` (`backend.log`, `frontend-install.log`, `frontend-lint.log`) for debugging.
+- The script exits non-zero on failure (allowing Pytest exit code `5` when no tests are collected) so CI/CD deployments clearly report failing steps.
+
 ## Open items / next steps
 
  - Refine toolkit prompts and add server-side validation.

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -1,11 +1,40 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Directory setup
+ROOT_DIR=$(dirname "$(readlink -f "$0")")/..
+LOG_DIR="$ROOT_DIR/test-results"
+mkdir -p "$LOG_DIR"
+
 echo "Running backend tests..."
-# Allow exit code 5 (no tests collected)
-python -m pytest backend || true
+# Capture output to log and record exit status. Pytest exit code 5 means no tests were collected.
+set +e
+python -m pytest backend 2>&1 | tee "$LOG_DIR/backend.log"
+backend_status=${PIPESTATUS[0]}
+set -e
+if [[ "$backend_status" -ne 0 && "$backend_status" -ne 5 ]]; then
+  echo "Backend tests failed (exit code $backend_status). See $LOG_DIR/backend.log for details."
+  exit "$backend_status"
+fi
 
 echo "Running frontend lint..."
-cd frontend
-npm ci
-npm run lint
+pushd frontend >/dev/null
+set +e
+npm ci 2>&1 | tee "$LOG_DIR/frontend-install.log"
+install_status=${PIPESTATUS[0]}
+if [[ "$install_status" -ne 0 ]]; then
+  echo "Frontend dependency installation failed (exit code $install_status). See $LOG_DIR/frontend-install.log for details."
+  popd >/dev/null
+  exit "$install_status"
+fi
+
+npm run lint 2>&1 | tee "$LOG_DIR/frontend-lint.log"
+lint_status=${PIPESTATUS[0]}
+set -e
+popd >/dev/null
+if [[ "$lint_status" -ne 0 ]]; then
+  echo "Frontend lint failed (exit code $lint_status). See $LOG_DIR/frontend-lint.log for details."
+  exit "$lint_status"
+fi
+
+echo "All tests and lint checks passed. Logs are available in $LOG_DIR."


### PR DESCRIPTION
## Summary
- add test-all.sh harness with detailed logging and failure handling
- document testing workflow in architecture.md
- ignore test-results directory

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6896c7b668f8832a812f9968005cbc79