### PR TITLE
fix: configure frontend cache dependency path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
       - run: npm ci
         working-directory: frontend
       - run: npm run lint


### PR DESCRIPTION
## Summary
- fix frontend CI cache configuration by pointing setup-node to frontend/package-lock.json

## Testing
- `pytest backend`
- `npm ci --prefix frontend`
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6896ca2cc7dc832a9b277d9686702679