### PR TITLE
Add basic health endpoint tests

### DIFF
--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,20 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_health_endpoint_returns_ok():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_ai_router_ping():
+    response = client.get("/ai/ping")
+    assert response.status_code == 200
+    assert response.json() == {"message": "AI router alive"}


### PR DESCRIPTION
## Summary
- add FastAPI tests for /health and /ai/ping endpoints

## Testing
- `pytest backend`


------
https://chatgpt.com/codex/tasks/task_e_6896cc053f44832aa96a4a5c99619b54